### PR TITLE
Update all python deps

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -2,13 +2,13 @@ import logging
 import os
 from os.path import basename, expanduser
 
+from cachelib.simple import SimpleCache
 from configargparse import ArgumentParser
 from jinja2 import Environment, FileSystemLoader
-from werkzeug.contrib.cache import SimpleCache
 from werkzeug.exceptions import HTTPException
+from werkzeug.middleware.shared_data import SharedDataMiddleware
 from werkzeug.routing import Map, Rule
 from werkzeug.wrappers import Request, Response
-from werkzeug.wsgi import SharedDataMiddleware
 
 logger = logging.getLogger("catpage")
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,12 @@
 -r requirements.txt
 black==18.9b0
-flake8==3.6.0
+flake8==3.7.8
 flake8-debugger==3.1.0
 flake8-docstrings==1.3.0
-flake8-isort==2.6.0
+flake8-isort==2.7.0
 flake8-string-format==0.2.3
-flake8-tuple==0.2.13
-isort==4.3.4
-pytest==4.1.1
-pytest-cov==2.6.1
+flake8-tuple==0.4.0
+isort==4.3.21
+pydocstyle<4.0.0 # https://gitlab.com/pycqa/flake8-docstrings/issues/36
+pytest==5.0.1
+pytest-cov==2.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Werkzeug==0.15.4
 Jinja2==2.10.1
 configargparse==0.14.0
-CherryPy==18.1.1
+CherryPy==18.1.2
+cachelib==0.1


### PR DESCRIPTION
Takes care of all the deps in one go and also fixes some deprecation warnings. I had to add in `pydocstyle<4.0.0` since `flake8-docstrings` needs an update to be compatible with 4.0.0.