### PR TITLE
ci(renovate): group all renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,20 @@
     "fileMatch": [
       "requirements.*txt$"
     ]
-  }
+  },
+  "packageRules": [
+    {
+      "extends": "monorepo:semantic-release",
+      "groupName": "semantic-release monorepo"
+    },
+    {
+      "packagePatterns": [
+        "*"
+      ],
+      "minor": {
+        "groupName": "all non-major dependencies",
+        "groupSlug": "all-minor-patch"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
We can cut down on noise by grouping all the renovate updates on this repo.