### PR TITLE
feat(container image): migrate to ghcr.io

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,14 +26,31 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: docker/build-push-action@v1
+    - name: Docker meta
+      id: docker_meta
+      uses: crazy-max/ghaction-docker-meta@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: radiorabe/catpage
-        add_git_labels: true
-        tag_with_ref: true
-        push: ${{ startsWith(github.ref, 'refs/tags/') }}
+        images: ghcr.io/radiorabe/catpage
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GH_PAT_TOKEN  }}
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outputs.labels }}
   release:
     runs-on: ubuntu-latest
     needs: test


### PR DESCRIPTION
Since [Docker Hub download rate limits](https://docs.docker.com/docker-hub/download-rate-limit/) are already pestering us I am migrating everything we can away from there.

What docker ist doing is a nice way to kill a product just to squeeze some cash out of enterprises though. I wonder how many folx just foot the bill because the costs of a migration are prohibitive (esp. if they don't own all the images they deploy).