### PR TITLE
chore(dev): update black

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-black==18.9b0
+black==20.8b1
 flake8==3.8.4
 flake8-debugger==3.2.1
 flake8-docstrings==1.5.0


### PR DESCRIPTION
Soooo.... what you're saying is that Python 3.9 should have clearly been tagged as 4.0 since this fix should not work if it followed semver properly?